### PR TITLE
solving problem in auto end amounts calculation

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -267,7 +267,7 @@ describe("calculateDepreciation()", () => {
     }])
   });
 
-  it("should not return endAmount of 1 for small amount like 31 purchase after Jan", () => {
+  it("should not return endAmount of 1 for small amount like 31 purchase - purchase made after Jan", () => {
     expect(calculateDepreciation({
       purchaseAmount: 31,
       purchaseDate: new Date("2018-02-01"),

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -270,6 +270,274 @@ describe("calculateDepreciation()", () => {
       }
     ]);
   });
+
+  it("should not return endAmount of 3", () => {
+    expect(calculateDepreciation({
+      purchaseAmount: 123000,
+      purchaseDate: new Date("2021-09-29"),
+      totalDepreciationYears: 7,
+    })).toEqual([
+      {
+        year: 2021,
+        depreciationMonths: 4,
+        depreciationAmount: 5857,
+        percentage: 0.04761788617886179,
+        startAmount: 123000,
+        endAmount: 117143
+      },
+      {
+        year: 2022,
+        depreciationMonths: 12,
+        depreciationAmount: 17571,
+        percentage: 0.14285365853658535,
+        startAmount: 117143,
+        endAmount: 99572
+      },
+      {
+        year: 2023,
+        depreciationMonths: 12,
+        depreciationAmount: 17571,
+        percentage: 0.14285365853658535,
+        startAmount: 99572,
+        endAmount: 82001
+      },
+      {
+        year: 2024,
+        depreciationMonths: 12,
+        depreciationAmount: 17571,
+        percentage: 0.14285365853658535,
+        startAmount: 82001,
+        endAmount: 64430
+      },
+      {
+        year: 2025,
+        depreciationMonths: 12,
+        depreciationAmount: 17571,
+        percentage: 0.14285365853658535,
+        startAmount: 64430,
+        endAmount: 46859
+      },
+      {
+        year: 2026,
+        depreciationMonths: 12,
+        depreciationAmount: 17571,
+        percentage: 0.14285365853658535,
+        startAmount: 46859,
+        endAmount: 29288
+      },
+      {
+        year: 2027,
+        depreciationMonths: 12,
+        depreciationAmount: 17571,
+        percentage: 0.14285365853658535,
+        startAmount: 29288,
+        endAmount: 11717
+      },
+      {
+        year: 2028,
+        depreciationMonths: 8,
+        depreciationAmount: 11717,
+        percentage: 0.09526016260162602,
+        startAmount: 11717,
+        endAmount: 0
+      }
+    ]);
+  });
+
+  it("should not return endAmount of 2", () => {
+    expect(calculateDepreciation({
+      purchaseAmount: 1230000,
+      purchaseDate: new Date("2021-09-29"),
+      totalDepreciationYears: 7,
+    })).toEqual([
+      {
+        year: 2021,
+        depreciationMonths: 4,
+        depreciationAmount: 58571,
+        percentage: 0.04761869918699187,
+        startAmount: 1230000,
+        endAmount: 1171429
+      },
+      {
+        year: 2022,
+        depreciationMonths: 12,
+        depreciationAmount: 175714,
+        percentage: 0.14285691056910568,
+        startAmount: 1171429,
+        endAmount: 995715
+      },
+      {
+        year: 2023,
+        depreciationMonths: 12,
+        depreciationAmount: 175714,
+        percentage: 0.14285691056910568,
+        startAmount: 995715,
+        endAmount: 820001
+      },
+      {
+        year: 2024,
+        depreciationMonths: 12,
+        depreciationAmount: 175714,
+        percentage: 0.14285691056910568,
+        startAmount: 820001,
+        endAmount: 644287
+      },
+      {
+        year: 2025,
+        depreciationMonths: 12,
+        depreciationAmount: 175714,
+        percentage: 0.14285691056910568,
+        startAmount: 644287,
+        endAmount: 468573
+      },
+      {
+        year: 2026,
+        depreciationMonths: 12,
+        depreciationAmount: 175714,
+        percentage: 0.14285691056910568,
+        startAmount: 468573,
+        endAmount: 292859
+      },
+      {
+        year: 2027,
+        depreciationMonths: 12,
+        depreciationAmount: 175714,
+        percentage: 0.14285691056910568,
+        startAmount: 292859,
+        endAmount: 117145
+      },
+      {
+        year: 2028,
+        depreciationMonths: 8,
+        depreciationAmount: 117145,
+        percentage: 0.09523983739837398,
+        startAmount: 117145,
+        endAmount: 0
+      }
+    ]);
+  });
+
+  it("should not return endAmount of 5", () => {
+    expect(calculateDepreciation({
+      purchaseAmount: 1230000,
+      purchaseDate: new Date("2021-09-29"),
+      totalDepreciationYears: 13,
+    })).toEqual([
+      {
+        year: 2021,
+        depreciationMonths: 4,
+        depreciationAmount: 31538,
+        percentage: 0.025640650406504064,
+        startAmount: 1230000,
+        endAmount: 1198462
+      },
+      {
+        year: 2022,
+        depreciationMonths: 12,
+        depreciationAmount: 94615,
+        percentage: 0.07692276422764227,
+        startAmount: 1198462,
+        endAmount: 1103847
+      },
+      {
+        year: 2023,
+        depreciationMonths: 12,
+        depreciationAmount: 94615,
+        percentage: 0.07692276422764227,
+        startAmount: 1103847,
+        endAmount: 1009232
+      },
+      {
+        year: 2024,
+        depreciationMonths: 12,
+        depreciationAmount: 94615,
+        percentage: 0.07692276422764227,
+        startAmount: 1009232,
+        endAmount: 914617
+      },
+      {
+        year: 2025,
+        depreciationMonths: 12,
+        depreciationAmount: 94615,
+        percentage: 0.07692276422764227,
+        startAmount: 914617,
+        endAmount: 820002
+      },
+      {
+        year: 2026,
+        depreciationMonths: 12,
+        depreciationAmount: 94615,
+        percentage: 0.07692276422764227,
+        startAmount: 820002,
+        endAmount: 725387
+      },
+      {
+        year: 2027,
+        depreciationMonths: 12,
+        depreciationAmount: 94615,
+        percentage: 0.07692276422764227,
+        startAmount: 725387,
+        endAmount: 630772
+      },
+      {
+        year: 2028,
+        depreciationMonths: 12,
+        depreciationAmount: 94615,
+        percentage: 0.07692276422764227,
+        startAmount: 630772,
+        endAmount: 536157
+      },
+      {
+        year: 2029,
+        depreciationMonths: 12,
+        depreciationAmount: 94615,
+        percentage: 0.07692276422764227,
+        startAmount: 536157,
+        endAmount: 441542
+      },
+      {
+        year: 2030,
+        depreciationMonths: 12,
+        depreciationAmount: 94615,
+        percentage: 0.07692276422764227,
+        startAmount: 441542,
+        endAmount: 346927
+      },
+      {
+        year: 2031,
+        depreciationMonths: 12,
+        depreciationAmount: 94615,
+        percentage: 0.07692276422764227,
+        startAmount: 346927,
+        endAmount: 252312
+      },
+      {
+        year: 2032,
+        depreciationMonths: 12,
+        depreciationAmount: 94615,
+        percentage: 0.07692276422764227,
+        startAmount: 252312,
+        endAmount: 157697
+      },
+      {
+        year: 2033,
+        depreciationMonths: 12,
+        depreciationAmount: 94615,
+        percentage: 0.07692276422764227,
+        startAmount: 157697,
+        endAmount: 63082
+      },
+      {
+        year: 2034,
+        depreciationMonths: 8,
+        depreciationAmount: 63082,
+        percentage: 0.05128617886178862,
+        startAmount: 63082,
+        endAmount: 0
+      }
+    ]);
+  });
+
 });
 
 describe("errors handler", () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -238,6 +238,73 @@ describe("calculateDepreciation()", () => {
     }])
   });
 
+  it("should not return endAmount of 1 for small amount like 31", () => {
+    expect(calculateDepreciation({
+      purchaseAmount: 31,
+      purchaseDate: new Date("2018-01-01"),
+      totalDepreciationYears: 3,
+    })).toEqual([{
+      year: 2018,
+      depreciationMonths: 12,
+      depreciationAmount: 10,
+      percentage: 0.3225806451612903,
+      startAmount: 31,
+      endAmount: 21,
+    }, {
+      year: 2019,
+      depreciationMonths: 12,
+      depreciationAmount: 10,
+      percentage: 0.3225806451612903,
+      startAmount: 21,
+      endAmount: 11,
+    }, {
+      year: 2020,
+      depreciationMonths: 12,
+      depreciationAmount: 11,
+      percentage: 0.3548387096774194,
+      startAmount: 11,
+      endAmount: 0,
+    }])
+  });
+
+  it("should not return endAmount of 1 for small amount like 31 purchase after Jan", () => {
+    expect(calculateDepreciation({
+      purchaseAmount: 31,
+      purchaseDate: new Date("2018-02-01"),
+      totalDepreciationYears: 3,
+    })).toEqual([{
+      year: 2018,
+      depreciationMonths: 11,
+      depreciationAmount: 9,
+      percentage: 0.2903225806451613,
+      startAmount: 31,
+      endAmount: 22,
+    }, {
+      year: 2019,
+      depreciationMonths: 12,
+      depreciationAmount: 10,
+      percentage: 0.3225806451612903,
+      startAmount: 22,
+      endAmount: 12,
+    }, {
+      year: 2020,
+      depreciationMonths: 12,
+      depreciationAmount: 10,
+      percentage: 0.3225806451612903,
+      startAmount: 12,
+      endAmount: 2,
+    },
+    {
+      year: 2021,
+      depreciationMonths: 1,
+      depreciationAmount: 2,
+      percentage: 0.06451612903225806,
+      startAmount: 2,
+      endAmount: 0,
+    }])
+  });
+
+
   it("should not return endAmount of -1", () => {
     expect(calculateDepreciation({
       purchaseAmount: 199900,

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -202,7 +202,7 @@ describe("calculateDepreciation()", () => {
     }])
   });
 
-  it("should not return endAmount of 1", () => {
+  it("should return endAmount of 0", () => {
     expect(calculateDepreciation({
       purchaseAmount: 250000,
       purchaseDate: new Date("2018-02-01"),
@@ -238,7 +238,7 @@ describe("calculateDepreciation()", () => {
     }])
   });
 
-  it("should not return endAmount of 1 for small amount like 31", () => {
+  it("should return endAmount of 0 for small amount like 31", () => {
     expect(calculateDepreciation({
       purchaseAmount: 31,
       purchaseDate: new Date("2018-01-01"),
@@ -267,7 +267,7 @@ describe("calculateDepreciation()", () => {
     }])
   });
 
-  it("should not return endAmount of 1 for small amount like 31 - purchase made after Jan", () => {
+  it("should return endAmount of 0 for small amount like 31 - purchase made after Jan", () => {
     expect(calculateDepreciation({
       purchaseAmount: 31,
       purchaseDate: new Date("2018-02-01"),
@@ -303,7 +303,6 @@ describe("calculateDepreciation()", () => {
       endAmount: 0,
     }])
   });
-
 
   it("should not return endAmount of -1", () => {
     expect(calculateDepreciation({
@@ -406,79 +405,6 @@ describe("calculateDepreciation()", () => {
         depreciationAmount: 11717,
         percentage: 0.09526016260162602,
         startAmount: 11717,
-        endAmount: 0
-      }
-    ]);
-  });
-
-  it("should not return endAmount of 2", () => {
-    expect(calculateDepreciation({
-      purchaseAmount: 1230000,
-      purchaseDate: new Date("2021-09-29"),
-      totalDepreciationYears: 7,
-    })).toEqual([
-      {
-        year: 2021,
-        depreciationMonths: 4,
-        depreciationAmount: 58571,
-        percentage: 0.04761869918699187,
-        startAmount: 1230000,
-        endAmount: 1171429
-      },
-      {
-        year: 2022,
-        depreciationMonths: 12,
-        depreciationAmount: 175714,
-        percentage: 0.14285691056910568,
-        startAmount: 1171429,
-        endAmount: 995715
-      },
-      {
-        year: 2023,
-        depreciationMonths: 12,
-        depreciationAmount: 175714,
-        percentage: 0.14285691056910568,
-        startAmount: 995715,
-        endAmount: 820001
-      },
-      {
-        year: 2024,
-        depreciationMonths: 12,
-        depreciationAmount: 175714,
-        percentage: 0.14285691056910568,
-        startAmount: 820001,
-        endAmount: 644287
-      },
-      {
-        year: 2025,
-        depreciationMonths: 12,
-        depreciationAmount: 175714,
-        percentage: 0.14285691056910568,
-        startAmount: 644287,
-        endAmount: 468573
-      },
-      {
-        year: 2026,
-        depreciationMonths: 12,
-        depreciationAmount: 175714,
-        percentage: 0.14285691056910568,
-        startAmount: 468573,
-        endAmount: 292859
-      },
-      {
-        year: 2027,
-        depreciationMonths: 12,
-        depreciationAmount: 175714,
-        percentage: 0.14285691056910568,
-        startAmount: 292859,
-        endAmount: 117145
-      },
-      {
-        year: 2028,
-        depreciationMonths: 8,
-        depreciationAmount: 117145,
-        percentage: 0.09523983739837398,
-        startAmount: 117145,
         endAmount: 0
       }
     ]);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -267,7 +267,7 @@ describe("calculateDepreciation()", () => {
     }])
   });
 
-  it("should not return endAmount of 1 for small amount like 31 purchase - purchase made after Jan", () => {
+  it("should not return endAmount of 1 for small amount like 31 - purchase made after Jan", () => {
     expect(calculateDepreciation({
       purchaseAmount: 31,
       purchaseDate: new Date("2018-02-01"),

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -238,7 +238,7 @@ describe("calculateDepreciation()", () => {
     }])
   });
 
-  it("should return endAmount of 0 for small amount like 31", () => {
+  it("should return endAmount of 0 for small amount like 31 - purchase made in Jan", () => {
     expect(calculateDepreciation({
       purchaseAmount: 31,
       purchaseDate: new Date("2018-01-01"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ const calculate = (
   // Because of the rounding, even if the calculation is correct, sometimes there is €0.01 left over in the last part.
   // For example, if total is 31, divided by 3 it would be 10 / 10 / 10.
   // Also, there's a case, such as 29, where it returns negative result.
-  // So, had been added isLastPart to input parametes for handle this case. 
+  // Therefore, we explicitly depreciate the previous year’s end amount in the last part.
   if (isLastPart) {
     return {
       depreciationAmount: previousEndAmount,

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,21 +97,21 @@ const calculateDepreciation = ({
   }
 
   const parts: number = purchaseMonth > 1 ? totalDepreciationYears + 1 : totalDepreciationYears;
-  const monthsInFirstYear: number = MONTHS_IN_YEAR - purchaseMonth + 1;
-  const monthsInLastYear: number = monthsInFirstYear === MONTHS_IN_YEAR ? MONTHS_IN_YEAR : MONTHS_IN_YEAR - monthsInFirstYear;
 
-  let monthsInThisYear: number = monthsInFirstYear;
+  let monthsInEachYear: number[] = Array(parts).fill(MONTHS_IN_YEAR);
+  //months in fisrt year
+  monthsInEachYear[0] = MONTHS_IN_YEAR - purchaseMonth + 1;
+  //months in last year
+  monthsInEachYear[monthsInEachYear.length - 1] = purchaseMonth - 1 > 0 ? purchaseMonth - 1 : MONTHS_IN_YEAR;
 
   for (let index = 0; index < parts; index++) {
-    const result = calculate(purchaseAmount, totalDepreciationYears, endAmount, monthsInThisYear, index === parts - 1);
+    const result = calculate(purchaseAmount, totalDepreciationYears, endAmount, monthsInEachYear[index], index === parts - 1);
     results.push({
       year: purchaseYear + index,
-      depreciationMonths: monthsInThisYear,
+      depreciationMonths: monthsInEachYear[index],
       ...result,
     });
     endAmount = result.endAmount;
-    // calculate months in year for next step and control the last year case.
-    monthsInThisYear = (index + 1 === parts - 1) ? monthsInLastYear : MONTHS_IN_YEAR;
   }
 
   return results;

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ const calculate = (
   const depreciationAmount = Math.round((purchaseAmount / totalDepreciationYears / MONTHS_IN_YEAR) * monthsLeft);
   const newEndAmount = previousEndAmount - depreciationAmount;
 
-  // Because of the rounding, even if the calculation is correct, sometimes there is €0.01 left over in last part.
+  // Because of the rounding, even if the calculation is correct, sometimes there is €0.01 left over in the last part.
   // For example, if total is 31, divided by 3 it would be 10 / 10 / 10.
   // Also, there's a case, such as 29, where it returns negative result.
   // So, had been added isLastPart to input parametes for handle this case. 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ const calculate = (
   totalDepreciationYears: number,
   previousEndAmount: number,
   monthsLeft: number,
-  isLastPart: boolean = false,
+  isLastPart: boolean,
 ): {
   depreciationAmount: number;
   percentage: number;
@@ -84,7 +84,7 @@ const calculateDepreciation = ({
   const results: DepreciationResult[] = [];
 
   let endAmount: number = purchaseAmount;
-  
+
   if (totalDepreciationYears === 0) {
     return [{
       year: purchaseYear,
@@ -97,24 +97,23 @@ const calculateDepreciation = ({
   }
 
   const parts: number = purchaseMonth > 1 ? totalDepreciationYears + 1 : totalDepreciationYears;
-  const monthsInFirstYear : number = MONTHS_IN_YEAR - purchaseMonth + 1;
-  const monthInLastYear : number = monthInFirstYear === MONTHS_IN_YEAR ? MONTHS_IN_YEAR : MONTHS_IN_YEAR - monthInFirstYear;
+  const monthsInFirstYear: number = MONTHS_IN_YEAR - purchaseMonth + 1;
+  const monthsInLastYear: number = monthsInFirstYear === MONTHS_IN_YEAR ? MONTHS_IN_YEAR : MONTHS_IN_YEAR - monthsInFirstYear;
 
-  let monthInThisYear : number = monthInFirstYear;
-  endAmount = purchaseAmount;
+  let monthsInThisYear: number = monthsInFirstYear;
 
-  for (let index = 0; index < parts; index++) {        
-    const result = calculate(purchaseAmount, totalDepreciationYears, endAmount, monthInThisYear, index === parts - 1);
+  for (let index = 0; index < parts; index++) {
+    const result = calculate(purchaseAmount, totalDepreciationYears, endAmount, monthsInThisYear, index === parts - 1);
     results.push({
       year: purchaseYear + index,
-      depreciationMonths: monthInThisYear,
+      depreciationMonths: monthsInThisYear,
       ...result,
     });
-    endAmount = result.endAmount;  
-    // calculate month in year for next step and control the last year case.
-    monthInThisYear = (index + 1 === parts - 1) ? monthInLastYear : MONTHS_IN_YEAR;
+    endAmount = result.endAmount;
+    // calculate months in year for next step and control the last year case.
+    monthsInThisYear = (index + 1 === parts - 1) ? monthsInLastYear : MONTHS_IN_YEAR;
   }
-  
+
   return results;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ const calculateDepreciation = ({
   }
 
   const parts: number = purchaseMonth > 1 ? totalDepreciationYears + 1 : totalDepreciationYears;
-  const monthInFirstYear : number = MONTHS_IN_YEAR - purchaseMonth + 1;
+  const monthsInFirstYear : number = MONTHS_IN_YEAR - purchaseMonth + 1;
   const monthInLastYear : number = monthInFirstYear === MONTHS_IN_YEAR ? MONTHS_IN_YEAR : MONTHS_IN_YEAR - monthInFirstYear;
 
   let monthInThisYear : number = monthInFirstYear;

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,9 +99,9 @@ const calculateDepreciation = ({
   const parts: number = purchaseMonth > 1 ? totalDepreciationYears + 1 : totalDepreciationYears;
 
   let monthsInEachYear: number[] = Array(parts).fill(MONTHS_IN_YEAR);
-  //months in fisrt year
+  //Months in fisrt year
   monthsInEachYear[0] = MONTHS_IN_YEAR - purchaseMonth + 1;
-  //months in last year
+  //Months in last year
   monthsInEachYear[monthsInEachYear.length - 1] = purchaseMonth > 1 ? purchaseMonth - 1 : MONTHS_IN_YEAR;
 
   for (let index = 0; index < parts; index++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ const calculateDepreciation = ({
   //months in fisrt year
   monthsInEachYear[0] = MONTHS_IN_YEAR - purchaseMonth + 1;
   //months in last year
-  monthsInEachYear[monthsInEachYear.length - 1] = purchaseMonth - 1 > 0 ? purchaseMonth - 1 : MONTHS_IN_YEAR;
+  monthsInEachYear[monthsInEachYear.length - 1] = purchaseMonth > 1 ? purchaseMonth - 1 : MONTHS_IN_YEAR;
 
   for (let index = 0; index < parts; index++) {
     const result = calculate(purchaseAmount, totalDepreciationYears, endAmount, monthsInEachYear[index], index === parts - 1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ const calculate = (
   // Because of the rounding, even if the calculation is correct, sometimes there is €0.01 left over.
   // For example, if total is 31, divided by 3 it would be 10 / 10 / 10.
   // Also, there's a case, such as 29, where it returns negative result.
-  if (newEndAmount <= 1) {
+  if (depreciationAmount / previousEndAmount >= 0.99) {
     return {
       depreciationAmount: previousEndAmount,
       percentage: previousEndAmount / purchaseAmount,


### PR DESCRIPTION
because of rounding the depreciation amount in each year 
`Math.round((purchaseAmount / totalDepreciationYears / MONTHS_IN_YEAR) * monthsLeft)`
in last part of depreciation, a state is possible to be remain some integer, on code this situation was predicted 
and handled, but exactly in this segment was better to checked the ratio of 
`depreciationAmount/previousEndAmount >= 0.99`  instead of  `newEndAmount <= 1`, 
like this situation the `newEndAmount` can be greater than `1` and not be true in this conditions 
so return some remain integer instead of `0` in last part.